### PR TITLE
Remove unused command line arg and docs

### DIFF
--- a/docs/how-to/run-a-server.rst
+++ b/docs/how-to/run-a-server.rst
@@ -1,10 +1,10 @@
 Run a server
 ============
 
-Coniql exposes an interface to Channels and Devices. A Channel maps to a single
-value, with timeStamp, status information, and display level metadata. A Device
-consists of nested Groups of named Channels. Channels can be backed by different
-data stores, provided via a plugin interface.
+Coniql exposes an interface to Channels. A Channel maps to a single
+value, with timeStamp, status information, and display level metadata. 
+Channels can be backed by different data stores, provided via a plugin 
+interface.
 
 For example:
 
@@ -170,50 +170,3 @@ Coniql can also provide its values over pvAccess. To try this out you will need 
 working installation of `EPICS 7 <https://epics.anl.gov/base/R7-0/index.php>`_. You can
 then start a soft IOC, or add the PVA plugin to IOCs to expose PVs. The PVs work
 like CA, but have the prefix ``pva://``
-
-
-Devices
--------
-
-If you run up coniql with a configuration file, it can also expose Devices. For instance
-of you run the example::
-
-    pipenv run python -m coniql tests/simdevices.coniql.yaml
-
-You can ask for a list of all the Devices with something like::
-
-  query {
-    getDevices(filter: "*") {
-      id
-    }
-  }
-
-You can get more details about a particular device with this::
-
-  query {
-    getDevice(id:"Xspress3") {
-      id
-      children(flatten:true) {
-        name
-        label
-        child {
-          __typename
-          ... on Channel {
-            id
-          }
-          ... on Device {
-            id
-          }
-          ... on Group {
-            layout
-            children {
-              name
-            }
-          }
-        }
-      }
-    }
-  }
-
-Then you will see a Device output, showing a flattened view of its child Channels
-and Devices. You can then recurse down to see "Xspress3.Channel1".

--- a/docs/reference/benchmark.rst
+++ b/docs/reference/benchmark.rst
@@ -4,7 +4,7 @@ Benchmarking
 In order to evaluate changes made to the server, we have developed some scripts which request increasingly large waveforms and measure the update rate.
 Benchmark scripts are written in both Python and js (using the Node runtime) in an attempt to remove language or runtime effects.
 It is possible other graphQL clients will provide different performance characteristics in the future, although we have good reason to believe we are currently hitting other limits.
-For more information on the results of benchmarking so far, see `this page <https://github.com/DiamondLightSource/cs-web-proto/wiki/Performance-with-Coniql>`_.
+For more information on the results of benchmarking so far, see `this page <https://github.com/dls-controls/cs-web-proto/wiki/Performance-with-Coniql>`_.
 
 Instructions
 ------------

--- a/src/coniql/app.py
+++ b/src/coniql/app.py
@@ -1,7 +1,6 @@
 import logging
 from argparse import ArgumentParser
 from datetime import timedelta
-from pathlib import Path
 from typing import Any, Optional
 
 import aiohttp_cors
@@ -115,13 +114,6 @@ def main(args=None) -> None:
     """
     parser = ArgumentParser(description="CONtrol system Interface over graphQL")
     parser.add_argument("--version", action="version", version=__version__)
-    parser.add_argument(
-        "config_paths",
-        metavar="PATH",
-        type=Path,
-        nargs="*",
-        help="Paths to .coniql.yaml files describing Channels and Devices",
-    )
     parser.add_argument(
         "--cors",
         action="store_true",


### PR DESCRIPTION
This feature has been removed (or was never fully implemented).

Also fixes a broken link that the Link Check CI noticed.

Closes #61 