### PR TITLE
Setup Integration builds

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -142,6 +142,7 @@ jobs:
         with:
           images: ${{ env.IMAGE_REPOSITORY }}
           tags: |
+            type=edge,branch=integration
             type=ref,event=tag
             type=raw,value=latest
 

--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -166,8 +166,8 @@ jobs:
           file: ./Dockerfile
           # If you have a long docker build, uncomment the following to turn on caching
           # For short build times this makes it a little slower
-          #cache-from: type=gha
-          #cache-to: type=gha,mode=max
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Test cli works in runtime image
         # Despite the name, .tags actually includes the full repo path as well

--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -141,10 +141,12 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: ${{ env.IMAGE_REPOSITORY }}
+          # Add the "edge" tag on all commits to the "integration" branch.
+          # Add the "latest" tag to repository tags only
           tags: |
             type=edge,branch=integration
             type=ref,event=tag
-            type=raw,value=latest
+            type=raw,value=latest, enable=${{ github.ref_type == 'tag' }}
 
       - name: Set up Docker Buildx
         id: buildx
@@ -155,6 +157,7 @@ jobs:
         with:
           build-args: |
             PIP_OPTIONS=-r lockfiles/requirements.txt dist/*.whl
+          # Push images to GHCR that are either repository tags or commits on the "integration" branch
           push: ${{ github.event_name == 'push' && ( github.ref_type == 'tag' || github.ref_name == 'integration' ) }}
           load: ${{ ! (github.event_name == 'push' && ( github.ref_type == 'tag' || github.ref_name == 'integration' )) }}
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
 env:
   # The target python version, which must match the Dockerfile version
-  CONTAINER_PYTHON: "3.11"
+  CONTAINER_PYTHON: "3.10"
 
 jobs:
   lint:

--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -155,8 +155,8 @@ jobs:
         with:
           build-args: |
             PIP_OPTIONS=-r lockfiles/requirements.txt dist/*.whl
-          push: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags') }}
-          load: ${{ ! (github.event_name == 'push' && startsWith(github.ref, 'refs/tags')) }}
+          push: ${{ github.event_name == 'push' && ( github.ref_type == 'tag' || github.ref_name == 'integration' ) }}
+          load: ${{ ! (github.event_name == 'push' && ( github.ref_type == 'tag' || github.ref_name == 'integration' )) }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           context: artifacts/

--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -26,11 +26,6 @@ jobs:
       - name: Lint
         run: tox -e pre-commit,mypy
 
-      - name: Install minimum python version
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python }}
-
   test:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
     strategy:

--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -170,7 +170,8 @@ jobs:
           #cache-to: type=gha,mode=max
 
       - name: Test cli works in runtime image
-        run: docker run ${{ env.IMAGE_REPOSITORY }} --version
+        # Despite the name, .tags actually includes the full repo path as well
+        run: docker run ${{ steps.meta.outputs.tags }} --version
 
   release:
     # upload to PyPI and make a release on every tag

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # The devcontainer should use the build target and run as root with podman
 # or docker with user namespaces.
 #
-FROM python:3.11 as build
+FROM python:3.10 as build
 
 ARG PIP_OPTIONS=.
 
@@ -24,7 +24,7 @@ WORKDIR /context
 # install python package into /venv
 RUN pip install ${PIP_OPTIONS}
 
-FROM python:3.11-slim as runtime
+FROM python:3.10-slim as runtime
 
 # Add apt-get system dependecies for runtime here if needed
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,4 +34,5 @@ ENV PATH=/venv/bin:$PATH
 
 # change this entrypoint if it is not the same as the repo
 ENTRYPOINT ["coniql"]
-CMD ["--version"]
+# Run coniql with CORS enabled.
+CMD ["--cors", "motordevices.coniql.yaml"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,4 +35,4 @@ ENV PATH=/venv/bin:$PATH
 # change this entrypoint if it is not the same as the repo
 ENTRYPOINT ["coniql"]
 # Run coniql with CORS enabled.
-CMD ["--cors", "motordevices.coniql.yaml"]
+CMD ["--cors"]


### PR DESCRIPTION
This PR sets up an Integration branch that will act as a pre-production testing branch.

All commits to this branch will trigger a CI build of the container, push it to GHCR, and attach the `edge` tag, removing it from previous images. This tag was chosen as it was suggested by the [docker/metadata-action](https://github.com/docker/metadata-action#typeedge) documentation. The Testing deployment of Coniql is configured to use this tag.

Any Git tag (as opposed to a Docker tag) committed to the repo will have the `latest` label attached to it, and removed from previous tags. The Production deployment of Coniql is configured to use this tag.

The Dockerfile itself is also tweaked to re-insert the `--cors` default command line argument, matching old behaviour.

Lastly, I removed an unnecessary step in the CI - it was a hold-over from before this repo adopted the skeleton
