### PR TITLE
Update container building, testing, and publishing from Skeleton

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -178,7 +178,7 @@ jobs:
             type=raw,value=latest, enable=${{ github.ref_type == 'tag' }}
 
       - name: Push cached image to container registry
-        if: github.ref_type == 'tag' # || github.ref_name == 'main'
+        if: github.ref_type == 'tag' || github.ref_name == 'integration'
         uses: docker/build-push-action@v3
         # This does not build the image again, it will find the image in the 
         # Docker cache and publish it


### PR DESCRIPTION
This PR merges in the [latest change to the Skeleton](https://github.com/DiamondLightSource/python3-pip-skeleton/pull/139) that improves how we handle building, testing, and publishing containers.

More importantly, it also makes it much easier to publish containers from multiple branches with separate sets of tags, while still enabling container building and testing on non-tagged branches.