### PR TITLE
Pin to version 0.181.0 of Strawberry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
 description = "Interface to control systems via GraphQL over websockets"
 dependencies = [
     "typing-extensions;python_version<'3.8'",
-    "strawberry-graphql",
+    "strawberry-graphql==0.181.0",
     "aioca>=1.7",
     "p4p",
     "ruamel.yaml",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,11 @@ classifiers = [
 description = "Interface to control systems via GraphQL over websockets"
 dependencies = [
     "typing-extensions;python_version<'3.8'",
+    # The Strawberry module is quite volatile so recommend pinning to a
+    # specific version and updating to latest after testing.
+    # Currently later versions break tests due to DeprecationWarning from Strawberry.
+    # See https://github.com/strawberry-graphql/strawberry/issues/2857.
+    # Can be updated when this has been fixed by Strawberry.
     "strawberry-graphql==0.181.0",
     "aioca>=1.7",
     "p4p",


### PR DESCRIPTION
Currently later versions of Strawberry (0.182.0+) break the tests (see #72). This PR will pin to an earlier version of Strawberry. When the issue is fixed in the Strawberry repo we can bump the version to the latest after testing. 