### PR TITLE
Add benchmarking performance test and run script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,7 @@ lockfiles/
 
 # Javascript files used for benchmarking tests
 node_modules/*
+
+# Benchmark files
+benchmark/*db
+benchmark/*.txt

--- a/benchmark/coniql_performance_test.py
+++ b/benchmark/coniql_performance_test.py
@@ -282,7 +282,7 @@ async def main():
     cpu_monitor_thread = threading.Thread(target=cpu_monitor, args=(signal,))
     cpu_monitor_thread.start()
 
-    # Create subsciption tasks for n_pvs
+    # Create subscription tasks for n_pvs
     for i in range(n_pvs):
         # Get the PV name
         pv_name = PV_PREFIX + str(i)

--- a/benchmark/coniql_performance_test.py
+++ b/benchmark/coniql_performance_test.py
@@ -92,7 +92,6 @@ class GraphQLClient:
                         else:
                             if msg_count > n_messages:
                                 break
-                                print("break")
                             msg_count = msg_count + 1
                     else:
                         continue

--- a/benchmark/coniql_performance_test.py
+++ b/benchmark/coniql_performance_test.py
@@ -301,11 +301,12 @@ async def main():
     # Await all subscriptions to complete
     try:
         await asyncio.gather(*task_list)
-        # Signal to CPU monitoring thread to stop recording CPU metrics
-        signal.signal_stop()
     except Exception as e:
         # Catch any exceptions so that we can still record results
         print("Exception caught: ", e)
+    finally:
+        # Signal to CPU monitoring thread to stop recording CPU metrics
+        signal.signal_stop()
 
     # Analyse results
     missing_average = 0

--- a/benchmark/coniql_performance_test.py
+++ b/benchmark/coniql_performance_test.py
@@ -1,0 +1,311 @@
+import asyncio
+import psutil
+import time
+import json
+import websockets
+import threading
+import argparse
+import datetime
+import sys
+
+
+# Constants
+cpu_average = 0
+memory_use = 0
+PV_PREFIX = "TEST:REC"
+subscriptions_list = {}
+thread_list = []
+
+parser = argparse.ArgumentParser(description='Process inputs')
+parser.add_argument(
+    "-n", 
+    "--npvs", 
+    action="store",
+    dest="n_pvs", 
+    default=1,
+    help="Number of PVs"
+    )
+parser.add_argument(
+    "-s", 
+    "--nsamples", 
+    action="store",
+    dest="n_samples", 
+    default=10,
+    help="Number of samples to collect"
+    )
+parser.add_argument(
+    "-p", 
+    "--protocol", 
+    action="store",
+    dest="ws_protocol", 
+    choices=['1', '2'],
+    default=1,
+    help="websocket protocol: 1 = graphql-ws, 2 = graphql-transport-ws"
+    )
+parser.add_argument(
+    "-f", 
+    "--file", 
+    action="store",
+    dest="output_file", 
+    default="performance_test_results.txt",
+    help="File to output results to"
+    )
+
+
+class GraphQLClient:
+    def __init__(self, endpoint, signal, ws_protocol):
+        self.endpoint = endpoint
+        self.signal = signal
+        self.ws_protocol = ws_protocol
+
+    async def subscribe(self, idid, query, handle, n_messages):
+        connection_init_message = json.dumps(
+            {"type": "connection_init", "payload": {}}
+        )
+
+        request_message_graphql_ws_protocol = json.dumps(
+            {"type": "start", "id": idid, "payload": {"query": query}}
+        )
+
+        request_message_graphql_transport_ws_protocol = json.dumps(
+            {"type": "subscribe", "id": idid, "payload": {"query": query}}
+        )
+
+        protocols = ["graphql-ws", "graphql-transport-ws"]
+
+        async with websockets.connect(
+            self.endpoint,
+            subprotocols=[protocols[self.ws_protocol-1]],
+        ) as websocket:
+            await websocket.send(connection_init_message)
+            if self.ws_protocol == 2:
+                await websocket.send(request_message_graphql_transport_ws_protocol)
+            else:
+                await websocket.send(request_message_graphql_ws_protocol)
+
+            msg_count = 0
+            async for response in websocket:
+                data = json.loads(response)
+                if data["type"] == "connection_ack":
+                    pass
+                elif data["type"] == "ka":
+                    pass
+                else:
+                    if self.signal.get_start():
+                        handle(data["payload"])
+                        if n_messages == None:
+                            # Do nothing and continue subscription indefinitely
+                            pass
+                        else:
+                            if msg_count > n_messages:
+                                break
+                                print("break")
+                            msg_count = msg_count + 1
+                    else:
+                        continue
+
+
+class StartStopSignal():
+    def __init__(self):
+        self.start = False
+        self.stop = False
+
+    def signal_start(self):
+        print("-> Starting monitor")
+        self.start = True
+
+    def signal_stop(self):
+        print("-> Stopping monitor")
+        self.stop = True
+
+    def get_start(self):
+        return self.start
+
+    def get_stop(self):
+        return self.stop
+
+
+class PVSubscription():
+    def __init__(self, pv):
+        self.pv = pv
+        self.values = []
+
+    def append(self, value):
+        self.values.append(value)
+
+    def get_values(self):
+        return self.values
+
+
+def cpu_monitor(signal):
+    pid = 0
+    for proc in psutil.process_iter(['pid', 'name']):
+        if proc.info["name"] == "coniql":
+            pid = proc.info["pid"] 
+            print("-> Monitoring PID: "+str(pid))
+
+    p = psutil.Process(pid)
+    mem = p.memory_info().rss/1000000
+    memi = mem
+    cpu_res = []
+    count = 0
+    while True:
+        if signal.get_stop():
+            break
+        if signal.get_start():
+            cpu = p.cpu_percent(interval=1.0)
+            mem = p.memory_info().rss/1000000
+            print("-> CPU: "+str(cpu)+", MEM: "+str(mem))
+            cpu_res.append(cpu)
+            if count == 0:
+                memi = mem
+            count += 1
+        time.sleep(0.1)
+
+    memf = mem
+    mem_use = memf - memi
+    # Remove last element which may have been taken after subscriptions finished
+    cpu_res.pop()
+    if len(cpu_res) > 0:
+        cpu_aver = sum(cpu_res)/(len(cpu_res))
+        global cpu_average 
+        cpu_average = cpu_aver
+        global memory_use
+        memory_use = mem_use
+
+
+def data_handler(data):
+    id = data["data"]["subscribeChannel"]["id"]
+    id = id.replace("ca://","")
+
+    # Add value to list
+    value = data["data"]["subscribeChannel"]["value"]["float"]
+    subscriptions_list[id].append(value)
+
+
+def get_subscription_query(pv_name):
+    return ("""subscription {
+  subscribeChannel(id: "ca://%s") {
+    id
+    time {
+        datetime
+    }
+    value {
+        string
+        float
+        base64Array {
+          numberType
+          base64
+        }
+      stringArray
+      }
+      status {
+        quality
+        message
+        mutable
+      }
+      display {
+        units
+        form
+        controlRange {
+          max
+          min
+        }
+        choices
+        precision
+      }
+    }
+  }""" % pv_name) 
+
+
+def coniql_subscription(client, pv_name, n_samples):
+    subscriptions_list[pv_name] = PVSubscription(pv_name)
+    asyncio.run( client.subscribe(idid=pv_name, query=get_subscription_query(pv_name), handle=data_handler, n_messages=n_samples))
+
+
+def main():
+    args = parser.parse_args()
+    n_pvs = int(args.n_pvs)
+    n_samples = int(args.n_samples)
+    ws_protocol = int(args.ws_protocol)
+
+    protocol = "graphql-ws"
+    if ws_protocol == 2:
+        protocol = "graphql-transport-ws"
+    print("-> Using the websocket protocol: '"+protocol+"'")
+
+    # Create and start subscriptions
+    signal = StartStopSignal()
+    client = GraphQLClient(endpoint="ws://0.0.0.0:8080/ws", signal=signal, ws_protocol=ws_protocol)
+    t = threading.Thread(target=cpu_monitor, args = (signal,))
+    t.start()
+    for i in range(n_pvs):
+        # Get the PV name
+        if i < 10:
+            pv_name = PV_PREFIX+"0"+str(i)
+        else:
+            pv_name = PV_PREFIX + str(i)
+
+        t = threading.Thread(target=coniql_subscription, args = (client, pv_name, n_samples,))
+        thread_list.append(t)
+        t.start()
+        print("-> Starting subscription: "+str(pv_name))
+
+    # Monitor subscription progress
+    signal.signal_start()
+    list_size_t0 = len(thread_list)
+    while True:
+        for thread in thread_list:
+            if not thread.is_alive():
+                thread_list.remove(thread)
+                if len(thread_list) == list_size_t0 - 1:
+                    print("-> Subscriptions starting to close at "+str(datetime.datetime.now()))
+                    signal.signal_stop()
+        if len(thread_list) == 0:
+            print("-> All subscriptions completed at "+str(datetime.datetime.now()))
+            break
+        time.sleep(0.1)
+
+    # Analyse results
+    missing_average = 0
+    missing_max = 0
+    for pv in subscriptions_list.keys():
+        res = subscriptions_list[pv].get_values()
+        if len(res) == 0:
+            break
+        expected_result = res[0]
+        missing = 0
+        for val in res:
+            if val != expected_result:
+                n_missed = val - expected_result
+                missing = missing + n_missed
+                expected_result = val + 1
+            else:
+                expected_result += 1
+
+        if missing > missing_max:
+            missing_max = missing
+        missing_average = missing_average + missing/n_pvs
+        sample_range = max(res) - min(res) + 1
+        print(pv+" processing complete: value range "+str(sample_range)+", missing "+str(missing))
+
+    # Collect results
+    time.sleep(1)
+
+    res_str =  "[{}](nPVs={}, nsamples={}, protocol={})| Av. missed events: {}| Max missed events: {}| CPU av.: {:.2f} %| Mem usage: {:.2f} MiB\n"\
+        .format(datetime.datetime.now(),n_pvs,n_samples,protocol,round(missing_average),missing_max,cpu_average,memory_use)
+    with open(args.output_file, 'a') as f:
+        f.write(res_str)
+
+    print("\n\n ****** SUMMARY ******")
+    print(" Average missed events = "+str(round(missing_average)))
+    print(" Max. missed events = "+str(missing_max))
+    print(" CPU average: "+str(cpu_average)+" %")
+    print(" Memory usage: "+str(memory_use)+" MiB")
+    print(" *********************\n")
+    sys.exit()
+
+
+if __name__ == "__main__":
+    main()
+    sys.exit()

--- a/benchmark/coniql_performance_test.py
+++ b/benchmark/coniql_performance_test.py
@@ -246,10 +246,7 @@ def main():
     t.start()
     for i in range(n_pvs):
         # Get the PV name
-        if i < 10:
-            pv_name = PV_PREFIX + "0" + str(i)
-        else:
-            pv_name = PV_PREFIX + str(i)
+        pv_name = PV_PREFIX + str(i)
 
         t = threading.Thread(
             target=coniql_subscription,

--- a/benchmark/run_performance_test.sh
+++ b/benchmark/run_performance_test.sh
@@ -1,0 +1,137 @@
+#!/bin/bash
+# Usage ./run_performance_test <path/to/coniql/venv> <number-of-clients>
+#   <path/to/coniql/venv> = path to the location of the python virtual 
+#                           environment where Coniql has been installed
+#   <number-of-clients>   = number of websocket clients to start up
+
+
+# Get command line arguments
+args=("$@")
+
+# Some parameters
+SUB_DIR="benchmark"
+N_PVS=100
+N_SAMPLES=1000
+# 1 = old, 2 = new
+PROTOCOL=2
+
+Help()
+{
+    echo " ************************************************************************ "
+    echo " Script to run Coniql performance tests "
+    echo " - Requires:"
+    echo "      - EPICS installed and available"
+    echo "      - Coniql installed into a Python virtual environment"
+    echo " - Usage:"
+    echo "     Run from the top of the coniql directory"
+    echo "       ./benchmark/run_performance_test <coniql-path> <number-of-clients>"
+    echo "     where:"
+    echo "       - <coniql-path> = path to Python virtual env where the Coniql"
+    echo "                         application has been installed"
+    echo "       - <number-of-clients> = number of websocket clients to run"
+    echo "     E.g."
+    echo "       ./benchmark/run_performance_test ../venv 2"
+    echo " ************************************************************************ "
+}
+
+if [ -z ${args[0]} ]; then
+    Help
+    exit
+elif [ ${args[0]} = "--help" ]; then
+    Help
+    exit 
+else
+    CONIQL_DIR=${args[0]}
+    if [ ! -d $CONIQL_DIR ]; then
+        echo "Coniql virtual env directory '$CONIQL_DIR' does not exist."
+        exit
+    fi
+fi
+
+if [ -z ${args[1]} ]; then
+    N_CLIENTS=1
+    echo "Number of clients not provided, defaulting to 1"
+else
+    N_CLIENTS=${args[1]} 
+    if ! [[ $N_CLIENTS =~ ^[0-9]+$ ]]; then
+        echo "Number of clients must be an integer"
+        exit
+    fi
+fi
+
+
+# Setup: create db file for EPICS 
+for ((i=0;i<N_PVS;i++))
+do
+    if [ $i -lt 10 ]; then 
+        str_name="0$i"
+    else
+        str_name="$i"
+    fi
+
+    STR="record(calcout, \"TEST:REC$str_name\"){ field(DESC, \"Performance test record\") \
+    field(SCAN, \".1 second\") field(A, \"0\") field(CALC, \"A + 1\") field(OUT, \"TEST:REC$str_name.A\")}"
+
+    if [ $i -eq 0 ]; then
+        echo $STR > $SUB_DIR/coniqlPerformanceTestDb.db
+    else 
+        echo $STR >> $SUB_DIR/coniqlPerformanceTestDb.db
+    fi
+done
+
+
+# 1. EPICS IOCS
+CMD1="softIoc -d $SUB_DIR/coniqlPerformanceTestDb.db"
+TAB1=(--tab -- bash -c "${CMD1}")
+echo "-> Starting EPICS IOC"
+gnome-terminal "${TAB1[@]}"
+
+
+#2. Coniql
+CMD2="sleep 2;source $CONIQL_DIR/bin/activate;coniql"
+TAB2=(--tab -- bash -c "${CMD2}")
+echo "-> Starting Coniql"
+gnome-terminal "${TAB2[@]}"
+
+
+# 3. Performance test
+OUTPUT_FILE="$SUB_DIR/performance_test_results_NClients_$N_CLIENTS.txt"
+PYCMD="python $SUB_DIR/coniql_performance_test.py -n $N_PVS -s $N_SAMPLES -p $PROTOCOL -f $OUTPUT_FILE"
+for ((i=1;i<=$N_CLIENTS;i++)) 
+do
+    VENV_DIR="venv_test$i"
+    INSTALL3="python -m venv $VENV_DIR;source $VENV_DIR/bin/activate;pip install --upgrade pip;\
+    pip install websockets;pip install psutil"
+    CLEANUP3="deactivate;rm -rf $VENV_DIR"
+    CMD3="sleep 1;$INSTALL3;$PYCMD;$CLEANUP3;sleep 10"
+    TAB3=(--tab -- bash -c "${CMD3}")
+    echo "-> Starting websocket client $i"
+    gnome-terminal "${TAB3[@]}"
+done
+
+
+# Monitor when the python performance test has finished
+loop=true
+running=false
+echo -n "-> Running "
+while $loop
+do
+    sleep 1
+    TASK=$(ps -ef | grep  "${PYCMD}" | grep -v grep | grep -v bash | awk '{print $2}')
+    if [ -z "${TASK}" ]; then
+        if $running; then
+            loop=false
+        fi
+    else
+        running=true
+    fi
+    echo -n "."
+done
+echo " Completed"
+
+# Clean up long running applications (EPICS & Coniql)
+pids=$(pgrep softIoc)
+kill -INT $pids
+pids=$(pgrep coniql)
+kill -INT $pids
+

--- a/benchmark/run_performance_test.sh
+++ b/benchmark/run_performance_test.sh
@@ -127,9 +127,6 @@ if [ -z $PROTOCOL ]; then
     echo "Websocket protocol not provided, defaulting to 'graphql-transport-ws' (2)"
 fi
 
-# Time script
-start_time="$(date -u +%s)"
-
 # Setup: create db file for EPICS 
 echo "-> Creating EPICS db with $N_PVS PVs"
 for ((i=0;i<$N_PVS;i++))
@@ -170,8 +167,8 @@ TAB2=(--tab -- bash -c "${CMD2_TO_LOG}")
 echo "-> Starting Coniql"
 gnome-terminal "${TAB2[@]}"
 
-
-
+# Time script from starting of the Python clients
+start_time="$(date -u +%s)"
 
 # 3. Performance test
 # Create a log directory for Python script in tmp

--- a/benchmark/run_performance_test.sh
+++ b/benchmark/run_performance_test.sh
@@ -171,18 +171,24 @@ echo "-> Starting Coniql"
 gnome-terminal "${TAB2[@]}"
 
 
+
+
 # 3. Performance test
+# Create a log directory for Python script in tmp
+TMP_DIR="/tmp/coniql_performance_tests_$(date +"%Y-%m-%d-%H:%M:%S")"
+mkdir -p "$TMP_DIR";
+# Define output and log file
 OUTPUT_FILE="$SUB_DIR/performance_test_results_NClients_$N_CLIENTS.txt"
+PY_PROGRESS_FILE="$TMP_DIR/test_progress.txt"
 PYCMD0="python $SUB_DIR/coniql_performance_test.py -n $N_PVS -s $N_SAMPLES -p $PROTOCOL -f $OUTPUT_FILE"
 for ((i=1;i<=$N_CLIENTS;i++)) 
 do
     PYCMD=$PYCMD0
     # Configure first client to monitor subscription progress
     if [ $i -eq 1 ]; then
-       PYCMD=$PYCMD0" -l" 
+       PYCMD=$PYCMD0" --log-file $PY_PROGRESS_FILE" 
     fi
     PYCMD_TO_LOG=$PYCMD" &> $LOG_DIR/performance_test_client$i.log"
-    echo $PYCMD_TO_LOG
     VENV="source $CONIQL_DIR/bin/activate"
     CLEANUP3="deactivate"
     CMD3="sleep 10;$VENV;$PYCMD_TO_LOG;$CLEANUP3;sleep 10"
@@ -207,7 +213,7 @@ do
         fi
     else
         running=true
-        tail=$(tail --lines=1 /tmp/progress.txt)
+        tail=$(tail --lines=1 $PY_PROGRESS_FILE)
         if [ "${tail}" != "${progress}" ]; then
             progress="${tail}"
             echo "   "$progress

--- a/benchmark/run_performance_test.sh
+++ b/benchmark/run_performance_test.sh
@@ -10,7 +10,6 @@ args=("$@")
 
 # Some parameters
 SUB_DIR="benchmark"
-N_PVS=100
 N_SAMPLES=1000
 # 1 = old, 2 = new
 PROTOCOL=2
@@ -25,12 +24,16 @@ Help()
     echo " - Usage:"
     echo "     Run from the top of the coniql directory"
     echo "       ./benchmark/run_performance_test <coniql-path> <number-of-clients>"
+    echo "          <number-of-pvs>"
     echo "     where:"
-    echo "       - <coniql-path> = path to Python virtual env where the Coniql"
-    echo "                         application has been installed"
-    echo "       - <number-of-clients> = number of websocket clients to run"
+    echo "       - <coniql-path> = [required] path to Python virtual env where the "
+    echo "                          Coniql application has been installed"
+    echo "       - <number-of-clients> = [optional] number of websocket clients to run."
+    echo "                                If not provided then default is 1."
+    echo "         <number-of-pvs> = [optional] number of PVs to subscribe to. If not "
+    echo "                            provided then default is 100."
     echo "     E.g."
-    echo "       ./benchmark/run_performance_test ../venv 2"
+    echo "       ./benchmark/run_performance_test ../venv 2 100"
     echo " ************************************************************************ "
 }
 
@@ -50,7 +53,7 @@ fi
 
 if [ -z ${args[1]} ]; then
     N_CLIENTS=1
-    echo "Number of clients not provided, defaulting to 1"
+    echo "Number of clients not provided, defaulting to $N_CLIENTS"
 else
     N_CLIENTS=${args[1]} 
     if ! [[ $N_CLIENTS =~ ^[0-9]+$ ]]; then
@@ -59,9 +62,21 @@ else
     fi
 fi
 
+if [ -z ${args[2]} ]; then
+    N_PVS=1
+    echo "Number of PVs not provided, defaulting to $N_PVS"
+else
+    N_PVS=${args[2]} 
+    if ! [[ $N_PVS =~ ^[0-9]+$ ]]; then
+        echo "Number of PVs must be an integer"
+        exit
+    fi
+fi
+
 
 # Setup: create db file for EPICS 
-for ((i=0;i<N_PVS;i++))
+echo "-> Creating EPICS db with $N_PVS PVs"
+for ((i=0;i<$N_PVS;i++))
 do
     if [ $i -lt 10 ]; then 
         str_name="0$i"
@@ -134,4 +149,3 @@ pids=$(pgrep softIoc)
 kill -INT $pids
 pids=$(pgrep coniql)
 kill -INT $pids
-

--- a/benchmark/run_performance_test.sh
+++ b/benchmark/run_performance_test.sh
@@ -180,10 +180,13 @@ PY_PROGRESS_FILE="$TMP_DIR/test_progress.txt"
 PYCMD0="python $SUB_DIR/coniql_performance_test.py -n $N_PVS -s $N_SAMPLES -p $PROTOCOL -f $OUTPUT_FILE"
 for ((i=1;i<=$N_CLIENTS;i++)) 
 do
-    PYCMD=$PYCMD0
     # Configure first client to monitor subscription progress
     if [ $i -eq 1 ]; then
-       PYCMD=$PYCMD0" --log-file $PY_PROGRESS_FILE" 
+        PYCMD=$PYCMD0" --log-file $PY_PROGRESS_FILE" 
+    else
+        # Subsequent clients should not create a CPU monitor
+        # as the first instance will handle this
+        PYCMD=$PYCMD0" --no-cpu-monitor"
     fi
     PYCMD_TO_LOG=$PYCMD" &> $LOG_DIR/performance_test_client$i.log"
     VENV="source $CONIQL_DIR/bin/activate"

--- a/benchmark/run_performance_test.sh
+++ b/benchmark/run_performance_test.sh
@@ -113,11 +113,9 @@ OUTPUT_FILE="$SUB_DIR/performance_test_results_NClients_$N_CLIENTS.txt"
 PYCMD="python $SUB_DIR/coniql_performance_test.py -n $N_PVS -s $N_SAMPLES -p $PROTOCOL -f $OUTPUT_FILE"
 for ((i=1;i<=$N_CLIENTS;i++)) 
 do
-    VENV_DIR="venv_test$i"
-    INSTALL3="python -m venv $VENV_DIR;source $VENV_DIR/bin/activate;pip install --upgrade pip;\
-    pip install websockets;pip install psutil"
-    CLEANUP3="deactivate;rm -rf $VENV_DIR"
-    CMD3="sleep 1;$INSTALL3;$PYCMD;$CLEANUP3;sleep 10"
+    VENV="source $CONIQL_DIR/bin/activate"
+    CLEANUP3="deactivate"
+    CMD3="sleep 10;$VENV;$PYCMD;$CLEANUP3;sleep 10"
     TAB3=(--tab -- bash -c "${CMD3}")
     echo "-> Starting websocket client $i"
     gnome-terminal "${TAB3[@]}"

--- a/benchmark/run_performance_test.sh
+++ b/benchmark/run_performance_test.sh
@@ -142,7 +142,9 @@ done
 echo " Completed"
 
 # Clean up long running applications (EPICS & Coniql)
-pids=$(pgrep softIoc)
-kill -INT $pids
-pids=$(pgrep coniql)
-kill -INT $pids
+for pid in $(pgrep softIoc) $(pgrep coniql)
+do
+    if [ -n "$pid" ]; then
+        kill -INT $pid
+    fi
+done

--- a/benchmark/run_performance_test.sh
+++ b/benchmark/run_performance_test.sh
@@ -78,21 +78,20 @@ fi
 echo "-> Creating EPICS db with $N_PVS PVs"
 for ((i=0;i<$N_PVS;i++))
 do
-    if [ $i -lt 10 ]; then 
-        str_name="0$i"
-    else
-        str_name="$i"
-    fi
 
-    STR="record(calcout, \"TEST:REC$str_name\"){ field(DESC, \"Performance test record\") \
-    field(SCAN, \".1 second\") field(A, \"0\") field(CALC, \"A + 1\") field(OUT, \"TEST:REC$str_name.A\")}"
+    record_name="TEST:REC$i"
+    cat <<EOF
+record(calcout, "$record_name")
+{
+    field(DESC, "Performance test record")
+    field(SCAN, ".1 second")
+    field(A, "0")
+    field(CALC, "A + 1")
+    field(OUT, "$record_name.A")
+}
+EOF
 
-    if [ $i -eq 0 ]; then
-        echo $STR > $SUB_DIR/coniqlPerformanceTestDb.db
-    else 
-        echo $STR >> $SUB_DIR/coniqlPerformanceTestDb.db
-    fi
-done
+done >$SUB_DIR/coniqlPerformanceTestDb.db
 
 
 # 1. EPICS IOCS

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ dev = [
     "sphinx-rtd-theme-github-versions",
     "tox-direct",
     "types-mock",
+    "psutil",                           # Required for benchmarking tests
     "pytest-asyncio>0.17",
     "pytest-aiohttp",
     "websockets",                       # Required for benchmarking tests


### PR DESCRIPTION
I have added the Python performance script (i.e. websocket client) that creates _N_ subscriptions to Coniql and measures memory usage, CPU and the number of missed updates. I have also added a bash script that takes care of creating the EPICS db, starts the IOC, starts Coniql and then runs _M_ instances of the Python ws client (to simulate multiple clients connecting to a single Coniql instance).

Results from the Python client script get appended to a file so that you can compare different runs.

The number of PVs to subscribe to, number of samples to collect and number of websocket clients are all configurable.

Do we want this version of the performance tests merged in as part of Coniql? They might be useful for individual developers to run locally when making changes. Otherwise the Python client can be used for the automated performance tests and we just use the bash script as a template. 