### PR TITLE
Fix timing issues in subscription tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -355,16 +355,29 @@ subscription {
     % PV_PREFIX
 )
 
-ticking_subscription_result = [
-    {
-        "subscribeChannel": {
-            "value": {"string": "0.00000 mm"},
-            "display": {"precision": 5, "units": "mm"},
-        }
-    },
-    {"subscribeChannel": {"value": {"string": "1.00000 mm"}, "display": None}},
-    {"subscribeChannel": {"value": {"string": "2.00000 mm"}, "display": None}},
-]
+
+def get_ticking_subscription_result(startVal):
+    return [
+        {
+            "subscribeChannel": {
+                "value": {"string": "{}0000 mm".format(startVal)},
+                "display": {"precision": 5, "units": "mm"},
+            }
+        },
+        {
+            "subscribeChannel": {
+                "value": {"string": "{}0000 mm".format(startVal + 1)},
+                "display": None,
+            }
+        },
+        {
+            "subscribeChannel": {
+                "value": {"string": "{}0000 mm".format(startVal + 2)},
+                "display": None,
+            }
+        },
+    ]
+
 
 subscribe_params = [
     (

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,6 +38,8 @@ BASE64_0_1688_2 = {
     "base64": "AAAAAAAAAAA1XrpJDAL7PwAAAAAAAABA",
 }
 
+SUBSCRIPTION_TIMEOUT = 10
+
 
 def wait_for_ioc(ioc):
     while True:
@@ -344,6 +346,7 @@ subscription {
     subscribeChannel(id: "ca://%sticking") {
         value {
             string(units: true)
+            float
         }
         display {
             precision
@@ -360,19 +363,19 @@ def get_ticking_subscription_result(startVal):
     return [
         {
             "subscribeChannel": {
-                "value": {"string": "{}0000 mm".format(startVal)},
+                "value": {"string": f"{startVal}0000 mm", "float": startVal},
                 "display": {"precision": 5, "units": "mm"},
             }
         },
         {
             "subscribeChannel": {
-                "value": {"string": "{}0000 mm".format(startVal + 1)},
+                "value": {"string": f"{startVal + 1}0000 mm", "float": startVal + 1},
                 "display": None,
             }
         },
         {
             "subscribeChannel": {
-                "value": {"string": "{}0000 mm".format(startVal + 2)},
+                "value": {"string": f"{startVal + 2}0000 mm", "float": startVal + 2},
                 "display": None,
             }
         },


### PR DESCRIPTION
This PR fixes the issue described in #64.

There is a timing issue relating to when you start a subscription to Coniql with respect to where the PV is in its update cycle (updating at 2Hz). Occasionally this can mean that you don't collect as many results in the time period as you expect, which causes the tests to fail.

Instead, I have changed these type of tests so that they collect 3 samples and check that no updates were missed (i.e. the results increment by 1 each time). I have also removed the need to ensure that the updating PV is reset to `0` for each test, which can also lead to some timing problems.

I've rerun the tests multiple times and no longer see failures but as this was always an intermittent problem we should still be aware of it.