### PR TITLE
Fix `Channel` type hint issues and update strawberry version to 0.190.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,10 +18,7 @@ dependencies = [
     "typing-extensions;python_version<'3.8'",
     # The Strawberry module is quite volatile so recommend pinning to a
     # specific version and updating to latest after testing.
-    # Currently later versions break tests due to DeprecationWarning from Strawberry.
-    # See https://github.com/strawberry-graphql/strawberry/issues/2857.
-    # Can be updated when this has been fixed by Strawberry.
-    "strawberry-graphql==0.181.0",
+    "strawberry-graphql==0.190.0",
     "aioca>=1.7",
     "p4p",
     "ruamel.yaml",

--- a/src/coniql/caplugin.py
+++ b/src/coniql/caplugin.py
@@ -33,6 +33,7 @@ from coniql.types import (
 )
 
 coniql_logger = logging.getLogger(__name__)
+TRANSPORT = "ca://"
 
 
 class CAChannelMaker:
@@ -136,15 +137,20 @@ class CAChannelMaker:
                     mutable=self.writeable,
                 )
                 self.cached_status = status
-        return CAChannel(value, time, status, display)
+        id = TRANSPORT + self.name
+        return CAChannel(id, value, time, status, display)
 
 
 @dataclass
 class CAChannel(Channel):
+    id: Optional[str]
     value: Optional[ChannelValue]
     time: Optional[ChannelTime]
     status: Optional[ChannelStatus]
     display: Optional[ChannelDisplay]
+
+    def get_id(self) -> Optional[str]:
+        return self.id
 
     def get_time(self) -> Optional[ChannelTime]:
         return self.time

--- a/src/coniql/simplugin.py
+++ b/src/coniql/simplugin.py
@@ -36,10 +36,14 @@ def register_channel(func: str):
 
 @dataclass
 class SimChannel(Channel):
+    id: Optional[str] = None
     value: Optional[ChannelValue] = None
     display: Optional[ChannelDisplay] = None
     time: Optional[ChannelTime] = None
     status: Optional[ChannelStatus] = None
+
+    def get_id(self) -> Optional[str]:
+        return self.id
 
     def get_value(self) -> Optional[ChannelValue]:
         return self.value

--- a/src/coniql/strawberry_schema.py
+++ b/src/coniql/strawberry_schema.py
@@ -16,6 +16,7 @@ from coniql.types import ChannelDisplay
 from coniql.types import ChannelStatus as TypeChannelStatus
 from coniql.types import ChannelTime as TypeChannelTime
 from coniql.types import ChannelValue as TypeChannelValue
+from coniql.types import TypeFloatAlias
 
 store_global = PluginStore()
 store_global.add_plugin("ssim", SimPlugin())
@@ -89,13 +90,15 @@ class ChannelValue:
     """
 
     # The current value formatted as a Float, Null if not expressable
-    float = strawberry.field(resolver=resolve_float)
+    float: Optional[TypeFloatAlias] = strawberry.field(resolver=resolve_float)
     # The current value formatted as a string
-    string = strawberry.field(resolver=resolve_string)
+    string: Optional[str] = strawberry.field(resolver=resolve_string)
     # Array of base64 encoded numbers, Null if not expressable
-    base64Array = strawberry.field(resolver=resolve_base64Array)
+    base64Array: Optional[TypeBase64Array] = strawberry.field(
+        resolver=resolve_base64Array
+    )
     # Array of strings, Null if not expressable
-    stringArray = strawberry.field(resolver=resolve_stringArray)
+    stringArray: Optional[List[str]] = strawberry.field(resolver=resolve_stringArray)
 
 
 @strawberry.type
@@ -171,7 +174,7 @@ def get_channel(id: strawberry.ID, timeout: float = 5.0) -> TypeChannel:
 @strawberry.type
 class Query:
     # Get the current value of a Channel
-    getChannel: Channel = strawberry.field(resolver=get_channel)
+    getChannel: Channel = strawberry.field(resolver=get_channel)  # type: ignore
 
 
 async def subscribe_channel(id: strawberry.ID) -> AsyncGenerator[TypeChannel, None]:

--- a/src/coniql/types.py
+++ b/src/coniql/types.py
@@ -281,6 +281,9 @@ class ChannelValue:
 
 
 class Channel:
+    def get_id(self) -> Optional[str]:
+        raise NotImplementedError(self)
+
     def get_value(self) -> Optional[ChannelValue]:
         raise NotImplementedError(self)
 

--- a/src/coniql/types.py
+++ b/src/coniql/types.py
@@ -65,6 +65,10 @@ DISPLAY_FORM_MAP = [
     DisplayForm.ENGINEERING,
 ]
 
+# GraphQL schema has a variable named 'float', which is an inbuilt type in Python
+# and can lead to problems when used in type hinting. Create alias inbuilt float type.
+TypeFloatAlias = float
+
 
 @strawberry.type
 class ChannelDisplay:


### PR DESCRIPTION
It would be worth us updating to the latest version of Strawberry was it contains a fix for the `KeyError` exceptions that we see when unsubscribing. The DeprecationWarnings described in #72 have also been fixed in this version.

Our pytests pass with this new version and a quick run of the performance tests on my local machine gave consisted performance.

The only problem I came across was tighter mypy type hinting checks. Some of our fields were missing type hints. A non-trivial one to solve was:
`float = strawberry.field(resolver=resolve_float)`
as `float` is an inbuilt Python type and it looks like we're trying to override is here. The format below causes the pytests to fail:
`float: float = strawberry.field(resolver=resolve_float)`
Instead I have had to create an alias for the `float` type and refer to that for the type hint.

The other problem I had was with errors from this type hinting
`getChannel: Channel = strawberry.field(resolver=get_channel)`
After several attempts I was unable to fix this so decided to add the flag to ignore this line. Perhaps not the best workaround but I could not find another way.