### PR TITLE
Increase test code coverage with extra query field

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -126,6 +126,7 @@ longout_get_query = (
     """
 query {
     getChannel(id: "ca://%slongout") {
+        id
         value {
             float
             string
@@ -164,6 +165,7 @@ query {
 
 longout_get_query_result = {
     "getChannel": {
+        "id": f"ca://{PV_PREFIX}longout",
         "value": {"float": 42.0, "string": "42"},
         "display": {
             "widget": "TEXTINPUT",


### PR DESCRIPTION
I've added the `id` field to a query in the tests to increase the code coverage of the refactored `Channel` in the strawberry_schema.py code.