### PR TITLE
Performance enhancements

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,75 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+.venv
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+**/_version.py
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+cov.xml
+.pytest_cache/
+.mypy_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# likely venv names
+.venv*
+venv*
+
+# further build artifacts
+lockfiles/
+
+# Javascript files used for benchmarking tests
+node_modules/*
+
+# Benchmark files
+benchmark/*db
+benchmark/*.txt

--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -32,12 +32,12 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest"] # can add windows-latest, macos-latest
-        python: ["3.8", "3.9", "3.10", "3.11"]
+        python: ["3.9", "3.10", "3.11"]
         install: ["-e .[dev]"]
         # Make one version be non-editable to test both paths of version code
         include:
           - os: "ubuntu-latest"
-            python: "3.7"
+            python: "3.8"
             install: ".[dev]"
 
     runs-on: ${{ matrix.os }}
@@ -146,9 +146,9 @@ jobs:
       - name: Build and export to Docker local cache
         uses: docker/build-push-action@v4
         with:
-        # Note build-args, context, file, and target must all match between this
-        # step and the later build-push-action, otherwise the second build-push-action
-        # will attempt to build the image again
+          # Note build-args, context, file, and target must all match between this
+          # step and the later build-push-action, otherwise the second build-push-action
+          # will attempt to build the image again
           build-args: |
             PIP_OPTIONS=-r lockfiles/requirements.txt dist/*.whl
           context: artifacts/
@@ -156,8 +156,8 @@ jobs:
           target: runtime
           load: true
           tags: ${{ env.TEST_TAG }}
-          # If you have a long docker build (2+ minutes), uncomment the 
-          # following to turn on caching. For short build times this 
+          # If you have a long docker build (2+ minutes), uncomment the
+          # following to turn on caching. For short build times this
           # makes it a little slower
           #cache-from: type=gha
           #cache-to: type=gha,mode=max
@@ -180,12 +180,12 @@ jobs:
       - name: Push cached image to container registry
         if: github.ref_type == 'tag' || github.ref_name == 'integration'
         uses: docker/build-push-action@v3
-        # This does not build the image again, it will find the image in the 
+        # This does not build the image again, it will find the image in the
         # Docker cache and publish it
         with:
-        # Note build-args, context, file, and target must all match between this
-        # step and the previous build-push-action, otherwise this step will 
-        # attempt to build the image again
+          # Note build-args, context, file, and target must all match between this
+          # step and the previous build-push-action, otherwise this step will
+          # attempt to build the image again
           build-args: |
             PIP_OPTIONS=-r lockfiles/requirements.txt dist/*.whl
           context: artifacts/

--- a/benchmark/Dockerfile
+++ b/benchmark/Dockerfile
@@ -3,19 +3,19 @@
 
 # perf_client contains the Python client code that connects to the Coniql
 # server via websockets
-FROM python:3.10 as perf_client
+FROM python:3.10-slim as perf_client
 
 # set up a virtual environment and put it in PATH
 RUN python -m venv /venv
 ENV PATH=/venv/bin:$PATH
 
-RUN pip install websockets
+RUN pip install websockets ujson
 
 # The Python client script
 COPY ./coniql_performance_test.py .
 
 # "-u" to force unbuffered output, to make print() statements
-# to be flushed to stdout as they occur, rather than being buffered
+# be flushed to stdout as they occur, rather than being buffered
 ENTRYPOINT [ "python", "-u", "./coniql_performance_test.py" ]
 
 # ioc generates a configurable sized DB, then runs an IOC

--- a/benchmark/run_performance_test.sh
+++ b/benchmark/run_performance_test.sh
@@ -64,7 +64,7 @@ while [ : ]; do
             shift 2
             ;;
         -c | --clients)
-            N_CLIENTS="$2" 
+            N_CLIENTS="$2"
             if ! [[ $N_CLIENTS =~ ^[0-9]+$ ]]; then
                 echo "Number of clients must be an integer"
                 exit
@@ -98,13 +98,13 @@ while [ : ]; do
             fi
             shift 2
             ;;
-        --) shift; 
-            break 
+        --) shift;
+            break
             ;;
     esac
 done
 
-# Check what variables have been set by user 
+# Check what variables have been set by user
 if [ -z $CONIQL_DIR ]; then
     echo "Coniql virtual env directory has not been provided."
     echo "Run './benchmark/run_performance_test --help' for script usage."
@@ -127,7 +127,7 @@ if [ -z $PROTOCOL ]; then
     echo "Websocket protocol not provided, defaulting to 'graphql-transport-ws' (2)"
 fi
 
-./generate_db.sh $SUB_DIR $N_PVS
+$SUB_DIR/generate_db.sh $SUB_DIR $N_PVS
 
 # Make directory to store logs
 LOG_DIR=$SUB_DIR"/logs"
@@ -160,12 +160,12 @@ mkdir -p "$TMP_DIR";
 # Define output and log file
 OUTPUT_FILE="$SUB_DIR/performance_test_results_NClients_$N_CLIENTS.txt"
 PY_PROGRESS_FILE="$TMP_DIR/test_progress.txt"
-PYCMD0="python $SUB_DIR/coniql_performance_test.py -n $N_PVS -s $N_SAMPLES -p $PROTOCOL -f $OUTPUT_FILE"
-for ((i=1;i<=$N_CLIENTS;i++)) 
+PYCMD0="python -u $SUB_DIR/coniql_performance_test.py -n $N_PVS -s $N_SAMPLES -p $PROTOCOL -f $OUTPUT_FILE"
+for ((i=1;i<=$N_CLIENTS;i++))
 do
     # Configure first client to monitor subscription progress
     if [ $i -eq 1 ]; then
-        PYCMD=$PYCMD0" --log-file $PY_PROGRESS_FILE" 
+        PYCMD=$PYCMD0" --log-file $PY_PROGRESS_FILE"
     else
         # Subsequent clients should not create a CPU monitor
         # as the first instance will handle this
@@ -201,7 +201,7 @@ do
             progress="${tail}"
             echo "   "$progress
         fi
-    fi   
+    fi
 done
 echo " Completed"
 

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -11,6 +11,7 @@ Practical step-by-step guides for the more experienced user.
     reference/api
     reference/benchmark
     reference/contributing
+    reference/performance
     Releases <https://github.com/DiamondLightSource/coniql/releases>
     Index <genindex.html#http://>
 

--- a/docs/reference/benchmark.rst
+++ b/docs/reference/benchmark.rst
@@ -2,21 +2,21 @@ Benchmarking
 ============
 
 In order to evaluate how changes made to the server impact the performance we have created a benchmarking script to measure the CPU usage, memory usage
-and the number of dropped updates. This script is written in Python. The script creates a websocket client and starts subscriptions to a configurable 
+and the number of dropped updates. This script is written in Python. The script creates a websocket client and starts subscriptions to a configurable
 number of EPICS PVs. A separate thread measures the CPU and memory usage of the Coniql application while the subscriptions are running. After _N_ samples
 have been collected the thread will finish and the average CPU and memory usage will be saved to file and printed to screen. The results of the subscriptions
 are also analysed to determine how many updates were missed by Coniql.
 
-These tests require an EPICS IOC running a specific _.db_ file with _N_ PVs counting up at a rate of 10 Hz. An instance of Coniql must also be running. 
+These tests require an EPICS IOC running a specific _.db_ file with _N_ PVs counting up at a rate of 10 Hz. An instance of Coniql must also be running.
 
-To facilitate the running of all these components a bash script has also been provided. This will handle the creation of the .db file, starting the 
+To facilitate the running of all these components a bash script has also been provided. This will handle the creation of the .db file, starting the
 EPICS IOC, starting Coniql, and running the Python performance tests.
 
 
 Instructions
 ------------
 
-Prerequisites 
+Prerequisites
 ~~~~~~~~~~~~~
 
 - EPICS installed
@@ -55,5 +55,5 @@ Results will be output to ``benchmark/performance_test_results_NClients_X.txt``.
 
 Logs from the EPICS IOC, Coniql and Python performance script will be saved in ``benchmark/logs/``.
 
-The results of the performance test should be compared between updates to the code. For the same number of clients, PVs, samples, and the same 
-websocket protocol check that the CPU, memory and number of dropped updates remains consistent with previous results. 
+The results of the performance test should be compared between updates to the code. For the same number of clients, PVs, samples, and the same
+websocket protocol check that the CPU, memory and number of dropped updates remains consistent with previous results.

--- a/docs/reference/performance.rst
+++ b/docs/reference/performance.rst
@@ -1,0 +1,47 @@
+Performance
+===========
+
+Coniql has had much work done to have the best performance for Subscriptions, which are the primary use case
+of most web GUIs, who are the primary consumers of Coniql data.
+
+Coniql can handle approximately 2,000 updates per second. This was tested using 10Hz PVs, subscribing to
+increasing numbers until updates were no longer being sent promptly.
+
+
+Investigating Coniql Performance
+--------------------------------
+
+
+Method
+^^^^^^
+
+The primary method used for investigating Coniql's performance has been `py-spy <https://github.com/benfred/py-spy>`_.
+This is a sampling profiler that can output speedscope-format data, which can then be viewed in the very nice
+`Speedscope web UI <https://www.speedscope.app/>`_.
+
+The profiles have been generates by first installing  ``py-spy``, then running the :doc:`benchmark` tests,
+modifying the Bash script to launch  ``py-spy``, for example::
+
+    CMD2="sleep 2;source $CONIQL_DIR/bin/activate;py-spy record --format speedscope --output speedscope-$(date +"%Y-%m-%d-%H:%M:%S") coniql"
+
+
+An example speedscope can be found in this directory.
+
+
+Findings
+^^^^^^^^
+
+Most of the time spent in processing results is done using ``async`` processing. The major performance gains so far have all come from
+minimizing the amount of ``async`` calls that are made in our code. For example all of our Resolvers are now synchronous.
+We do have to have some ``async`` calls, as we must use ``aioca`` to monitor PVs. These occur on initial calls to Query, Mutations,
+and Subscriptions, in a stage before the Resolvers are called.
+
+The current sampling shows that 80% of the time is spent in ``operation_task()``, which is a high level function inside Strawberry.
+This code calls into the lower level ``graphql`` library for most of its runtime. Broadly, these calls handle the GraphQL protocol,
+parsing the requested fields into calls to our library for data, then parsing that data back out to return the requested fields
+to the client.
+
+It is unclear why exactly this process seems to have so much overhead - further investigation is required.
+
+Approxmately 1% of time is spent directly in Coniql code. Most of that is inside of the ``aioca`` callbacks. Additional performance gains in this
+area are unlikely to be worthwhile as the possible gains are so small.

--- a/docs/tutorials/installation.rst
+++ b/docs/tutorials/installation.rst
@@ -14,7 +14,7 @@ Installation
 Check your version of python
 ----------------------------
 
-You will need python 3.7 or later. You can check your version of python by
+You will need python 3.8 or later. You can check your version of python by
 typing into a terminal::
 
     python3 --version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,8 @@ dev = [
     "psutil",                           # Required for benchmarking tests
     "pytest-asyncio>0.17",
     "pytest-aiohttp",
+    "types-ujson",
+    "ujson",
     "websockets",                       # Required for benchmarking tests
 ]
 
@@ -116,8 +118,8 @@ skipsdist=True
 # Don't create a virtualenv for the command, requires tox-direct plugin
 direct = True
 passenv = *
-allowlist_externals = 
-    pytest 
+allowlist_externals =
+    pytest
     pre-commit
     mypy
     sphinx-build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,6 @@ name = "coniql"
 classifiers = [
     "Development Status :: 4 - Beta",
     "License :: OSI Approved :: Apache Software License",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
 dynamic = ["version"]
 license.file = "LICENSE"
 readme = "README.rst"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 
 [project.optional-dependencies]
 dev = [

--- a/src/coniql/app.py
+++ b/src/coniql/app.py
@@ -7,6 +7,7 @@ import aiohttp_cors
 from aiohttp import web
 from aiohttp.hdrs import METH_GET, METH_POST
 from strawberry.aiohttp.views import GraphQLView
+from strawberry.schema.config import StrawberryConfig
 from strawberry.subscriptions import GRAPHQL_TRANSPORT_WS_PROTOCOL, GRAPHQL_WS_PROTOCOL
 
 import coniql.strawberry_schema as schema
@@ -23,12 +24,18 @@ from . import __version__
 
 
 def create_schema(debug: bool):
+    # Disabling automatic camel casing saves ~1% CPU time as Strawberry won't attempt
+    # to check/change our field names. Currently we don't have any snake_case fields
+    # so there isn't any transformation happening anyway.
+    config = StrawberryConfig(auto_camel_case=False)
+
     # Create the schema
     return MetricsSchema(
         query=schema.Query,
         subscription=schema.Subscription,
         mutation=schema.Mutation,
         extensions=[MetricsExtension],
+        config=config,
     )
 
 

--- a/src/coniql/caplugin.py
+++ b/src/coniql/caplugin.py
@@ -116,7 +116,7 @@ class CAChannelMaker:
             if time_value.ok:
                 assert time_value.timestamp
                 value = ChannelValue(time_value, self.formatter)
-                quality = ChannelQuality.get_channel_quality_str(time_value.severity)
+                quality = str(ChannelQuality(time_value.severity))
                 if self.cached_status is None or self.cached_status.quality != quality:
                     status = ChannelStatus(
                         quality=quality,

--- a/src/coniql/strawberry_schema.py
+++ b/src/coniql/strawberry_schema.py
@@ -23,26 +23,24 @@ store_global.add_plugin("ssim", SimPlugin())
 store_global.add_plugin("ca", CAPlugin(), set_default=True)
 
 
-async def resolve_float(root: TypeChannelValue) -> Optional[float]:
+def resolve_float(root: TypeChannelValue) -> Optional[float]:
     return root.formatter.to_float(root.value)
 
 
-async def resolve_string(root: TypeChannelValue, units: bool = False) -> Optional[str]:
+def resolve_string(root: TypeChannelValue, units: bool = False) -> Optional[str]:
     if units:
         return root.formatter.to_string_with_units(root.value)
     else:
         return root.formatter.to_string(root.value)
 
 
-async def resolve_base64Array(
+def resolve_base64Array(
     root: TypeChannelValue, length: int = 0
 ) -> Optional[TypeBase64Array]:
     return root.formatter.to_base64_array(root.value, length)
 
 
-async def resolve_stringArray(
-    root: TypeChannelValue, length: int = 0
-) -> Optional[List[str]]:
+def resolve_stringArray(root: TypeChannelValue, length: int = 0) -> Optional[List[str]]:
     return root.formatter.to_string_array(root.value, length)
 
 

--- a/src/coniql/types.py
+++ b/src/coniql/types.py
@@ -2,7 +2,7 @@ import base64
 import math
 import time
 from dataclasses import dataclass
-from enum import Enum
+from enum import Enum, IntEnum
 from typing import Any, Callable, List, Optional
 
 import numpy as np
@@ -30,28 +30,30 @@ class Range:
         return rmin <= value <= rmax
 
 
-class ChannelQuality(Enum):
+class ChannelQuality(IntEnum):
     """
     Indication of how the current value of a Channel should be interpreted
+
+    Note: The values align to the "menuAlarmSevr" enum in EPICS, with a couple of
+    extension values.
     """
 
     # Value is known, valid, nothing is wrong
-    VALID = "VALID"
+    VALID = 0
     # Value is known, valid, but is in the range generating a warning
-    WARNING = "WARNING"
+    WARNING = 1
     # Value is known, valid, but is in the range generating an alarm condition
-    ALARM = "ALARM"
+    ALARM = 2
     # Value is known, but not valid, e.g. a RW before its first put
-    INVALID = "INVALID"
+    INVALID = 3
     # The value is unknown, for instance because the channel is disconnected
-    UNDEFINED = "UNDEFINED"
+    UNDEFINED = 4
     # The Channel is currently in the process of being changed
-    CHANGING = "CHANGING"
+    CHANGING = 5
 
-    @classmethod
-    def get_channel_quality_str(cls, severity: int) -> str:
-        channel_quality_map = [key.value for key in cls]
-        return channel_quality_map[severity]
+    def __str__(self):
+        # Returns the Enum item as a string e.g. "VALID", rather than integer value
+        return self.name
 
 
 # Map from display form to DisplayForm enum


### PR DESCRIPTION
This branch contains a number of performance enhancements for Coniql. This is a 20-25% decrease in CPU usage, which effectively increases Coniql's requests-per-second from ~1,000 to ~2,000, with larger performance gains for 5+ clients subscribing to the same set of PVs.

The largest performance gains have been from simply removing the `async` keyword wherever possible. Additional gains have been made by creating a connection pool in the CA Plugin, which means we only have 1 `camonitor` per PV, regardless of the number of client subscriptions for that PV.

There is also a fair amount of work enhancing the Python performance tests in here, although those changes do not affect Coniql's performance.

There is a new document titled "Performance", which goes into some details about the work done and where time is spent. Please let me know if this should have more details added.

Also of note is dropping Python 3.7 support. This is really only for proper type hint support, so I'm open to reverting that if we decide it is a bad idea.

Closes #86 (by deleting that code)
