### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           requirements_file: requirements-dev-3.x.txt
           install_options: -e .[dev]
-          python_version: "3.11"
+          python_version: "3.11" # Pinned to 3.11 https://github.com/DiamondLightSource/coniql/issues/101
 
       - name: Lint
         run: tox -e pre-commit,mypy

--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           requirements_file: requirements-dev-3.x.txt
           install_options: -e .[dev]
+          python_version: "3.11"
 
       - name: Lint
         run: tox -e pre-commit,mypy

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,6 +32,7 @@ jobs:
         with:
           requirements_file: requirements-dev-3.x.txt
           install_options: -e .[dev]
+          python_version: "3.8"
 
       - name: Build docs
         run: tox -e docs

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           requirements_file: requirements-dev-3.x.txt
           install_options: -e .[dev]
-          python_version: "3.11"
+          python_version: "3.11" # Pinned to 3.11 https://github.com/DiamondLightSource/coniql/issues/101
 
       - name: Build docs
         run: tox -e docs

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           requirements_file: requirements-dev-3.x.txt
           install_options: -e .[dev]
-          python_version: "3.8"
+          python_version: "3.11"
 
       - name: Build docs
         run: tox -e docs

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -19,6 +19,7 @@ jobs:
         with:
           requirements_file: requirements-dev-3.x.txt
           install_options: -e .[dev]
+          python_version: "3.11"
 
       - name: Check links
         run: tox -e docs build -- -b linkcheck

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           requirements_file: requirements-dev-3.x.txt
           install_options: -e .[dev]
-          python_version: "3.11"
+          python_version: "3.11" # Pinned to 3.11 https://github.com/DiamondLightSource/coniql/issues/101
 
       - name: Check links
         run: tox -e docs build -- -b linkcheck

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,7 @@ addopts = """
     --cov=coniql --cov-report term --cov-report xml:cov.xml
     """
 # https://iscinumpy.gitlab.io/post/bound-version-constraints/#watch-for-warnings
+# Commented out because of https://github.com/DiamondLightSource/coniql/issues/101
 # filterwarnings = "error"
 # Doctest python code in docs, python code in src docstrings, test functions in tests
 testpaths = "docs src tests"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,7 @@ addopts = """
     --cov=coniql --cov-report term --cov-report xml:cov.xml
     """
 # https://iscinumpy.gitlab.io/post/bound-version-constraints/#watch-for-warnings
-filterwarnings = "error"
+# filterwarnings = "error"
 # Doctest python code in docs, python code in src docstrings, test functions in tests
 testpaths = "docs src tests"
 asyncio_mode = "auto"


### PR DESCRIPTION
Python 3.12 was causing various github actions to fail, due to deprecation of distutils. I have pinned python versions to 3.11 where necessary, and also removed the pytest config that treats warnings as errors. I will also open an issue for this issues to be handled in the longer term.