### PR TITLE
PIn version python:3.10.13 in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # The devcontainer should use the build target and run as root with podman
 # or docker with user namespaces.
 #
-FROM python:3.10 as build
+FROM python:3.10.13 as build
 
 ARG PIP_OPTIONS=.
 
@@ -24,7 +24,7 @@ WORKDIR /context
 # install python package into /venv
 RUN pip install ${PIP_OPTIONS}
 
-FROM python:3.10-slim as runtime
+FROM python:3.10.13-slim as runtime
 
 # Add apt-get system dependecies for runtime here if needed
 


### PR DESCRIPTION
Changed coniql dockerfile to use latest version of python 3.10 slim docker image. Currently we use just 3.10-slim, which uses the latest patch version that is available. Changing this to 3.10.13 will allow us to use the latest patch version, released in December, rather than 5 months ago, but also prevents any changes through patches that could break further down the line. I would like to do this in order to get patches available for CVEs that the Kubernetes scanner Stackrox has detected there are upstream fixes for.