### PR TITLE
Update CI pushing image to registry

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -189,7 +189,7 @@ jobs:
             type=semver,pattern={{version}},value=${{ env.LATEST_TAG }},enable=${{github.event_name == 'workflow_dispatch'}}
 
       - name: Push cached image to container registry
-        if: github.ref_type == 'tag' || github.ref_name == 'integration'
+        if: github.ref_type == 'tag' || github.ref_name == 'integration' || github.event_name == 'workflow_dispatch'
         uses: docker/build-push-action@v3
         # This does not build the image again, it will find the image in the
         # Docker cache and publish it


### PR DESCRIPTION
Added a missing clause to the if statement in the "Push cached image to container registry" step of the CI. This triggers the image push when the workflow has been manually triggered. This was missing in the previous PR by accident