### PR TITLE
Fix CI env variable syntax

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -133,7 +133,7 @@ jobs:
       # Fetch latest tag on this branch if manually triggered
       - name: Fetch latest tag
         if: github.event_name == 'workflow_dispatch'
-        run: echo "LATEST_TAG=git tag | sort --version-sort | tail -n1" >> $GITHUB_ENV
+        run: echo "LATEST_TAG=$(git tag | sort --version-sort | tail -n1)" >> $GITHUB_ENV
 
       - name: Download wheel and lockfiles
         uses: actions/download-artifact@v3


### PR DESCRIPTION
This should fix the current broken manual pipeline by correctly assigning git tag to env variable.